### PR TITLE
Move the OpsLevel POST workflow

### DIFF
--- a/.github/workflows/send-default-branch-name-to-opslevel.yaml
+++ b/.github/workflows/send-default-branch-name-to-opslevel.yaml
@@ -34,7 +34,8 @@ jobs:
             core.info('Fetched repositories:')
             core.info(names.join(',\n'))
 
-            return repositories
+            const mapped = repositories.map(r => ({ repository: r.name, defaultBranch: r.default_branch }))
+            return mapped
 
   send-to-opslevel:
     name: Send repository data to OpsLevel
@@ -48,4 +49,4 @@ jobs:
       - name: POST default branch name to OpsLevel
         if: github.event.action != 'push'
         run: |
-          echo '{ "repository": "${{ matrix.repository.name }}", "defaultBranch": "${{ matrix.repository.default_branch }}" }' | curl --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 40 -X POST https://app.opslevel.com/integrations/custom_event/4e9ed0d8-b835-47ab-948f-628e04448ce8 -H 'content-type: application/json' --data-binary @-
+          echo '{ "repository": "${{ matrix.repository.repository }}", "defaultBranch": "${{ matrix.repository.defaultBranch }}" }' | curl --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 40 -X POST https://app.opslevel.com/integrations/custom_event/4e9ed0d8-b835-47ab-948f-628e04448ce8 -H 'content-type: application/json' --data-binary @-

--- a/.github/workflows/send-default-branch-name-to-opslevel.yaml
+++ b/.github/workflows/send-default-branch-name-to-opslevel.yaml
@@ -24,7 +24,7 @@ jobs:
         with:
           result-encoding: string
           script: |
-            const repositories = await github.paginate("GET /repos/pleo-io/repos", {
+            const repositories = await github.paginate("GET /orgs/pleo-io/repos", {
               per_page: 100,
               headers: {
                 "X-GitHub-Api-Version": "2022-11-28",

--- a/.github/workflows/send-default-branch-name-to-opslevel.yaml
+++ b/.github/workflows/send-default-branch-name-to-opslevel.yaml
@@ -44,4 +44,4 @@ jobs:
     steps:
       - name: POST default branch name to OpsLevel
         run: |
-          echo '{ "repository": "${{ matrix.repository.repository }}", "defaultBranch": "${{ matrix.repository.defaultBranch }}" }' | curl --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 40 -X POST https://app.opslevel.com/integrations/custom_event/4e9ed0d8-b835-47ab-948f-628e04448ce8 -H 'content-type: application/json' --data-binary @-
+          echo '{ "repository": "${{ matrix.repository.repository }}", "defaultBranch": "${{ matrix.repository.defaultBranch }}" }' | curl --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 40 -X POST https://app.opslevel.com/integrations/custom_event/${{ secrets.OPSLEVEL_CUSTOM_EVENT_WEBHOOK }} -H 'content-type: application/json' --data-binary @-

--- a/.github/workflows/send-default-branch-name-to-opslevel.yaml
+++ b/.github/workflows/send-default-branch-name-to-opslevel.yaml
@@ -30,6 +30,8 @@ jobs:
                 "X-GitHub-Api-Version": "2022-11-28",
               },
             })
+            core.info('Fetched repositories:')
+            core.info(repositories)
 
             return JSON.stringify(repositories)
 
@@ -39,7 +41,7 @@ jobs:
     needs: get-github-repositories
     strategy:
       matrix:
-        repository: fromJSON(${{ needs.outputs.repositories }})
+        repository: fromJSON('${{ needs.outputs.repositories }}')
 
     steps:
       - name: POST default branch name to OpsLevel

--- a/.github/workflows/send-default-branch-name-to-opslevel.yaml
+++ b/.github/workflows/send-default-branch-name-to-opslevel.yaml
@@ -29,9 +29,6 @@ jobs:
                 "X-GitHub-Api-Version": "2022-11-28",
               },
             })
-            const names = repositories.map(r => r.name)
-            core.info('Fetched repositories:')
-            core.info(names.join(',\n'))
 
             const mapped = repositories.filter(r => !r.archived).map(r => ({ repository: r.name, defaultBranch: r.default_branch }))
             return mapped

--- a/.github/workflows/send-default-branch-name-to-opslevel.yaml
+++ b/.github/workflows/send-default-branch-name-to-opslevel.yaml
@@ -18,9 +18,18 @@ jobs:
       repositories: ${{ steps.fetch-all-repositories.outputs.result }}
 
     steps:
+      - name: Allow pushing version updates to the default branch
+        id: get-admin-token
+        uses: peter-murray/workflow-application-token-action@v2
+        with:
+          application_id: ${{ secrets.PLEO_GH_APP_TOKEN_SIGNER_APP_ID }}
+          application_private_key: ${{ secrets.PLEO_GH_APP_TOKEN_SIGNER_PRIVATE_KEY }}
+
       - name: Get all repositories
         uses: actions/github-script@v6
         id: fetch-all-repositories
+        env:
+          GITHUB_TOKEN: ${{ steps.get-admin-token.outputs.token }}
         with:
           script: |
             const repositories = await github.paginate("GET /orgs/pleo-io/repos?type=all", {
@@ -35,8 +44,8 @@ jobs:
 
             return repositories
 
-  post-opslevel:
-    name: Fetch repositories from GitHub
+  send-to-opslevel:
+    name: Send repository data to OpsLevel
     runs-on: ubuntu-latest
     needs: get-github-repositories
     strategy:

--- a/.github/workflows/send-default-branch-name-to-opslevel.yaml
+++ b/.github/workflows/send-default-branch-name-to-opslevel.yaml
@@ -42,7 +42,7 @@ jobs:
     needs: get-github-repositories
     strategy:
       matrix:
-        repository: fromJSON('${{ needs.get-github-repositories.outputs.repositories }}')
+        repository: fromJSON(${{ needs.get-github-repositories.outputs.repositories }})
 
     steps:
       - name: POST default branch name to OpsLevel

--- a/.github/workflows/send-default-branch-name-to-opslevel.yaml
+++ b/.github/workflows/send-default-branch-name-to-opslevel.yaml
@@ -30,10 +30,11 @@ jobs:
                 "X-GitHub-Api-Version": "2022-11-28",
               },
             })
+            const stringified = JSON.stringify(repositories)
             core.info('Fetched repositories:')
-            core.info(repositories)
+            core.info(stringified)
 
-            return JSON.stringify(repositories)
+            return stringified
 
   post-opslevel:
     name: Fetch repositories from GitHub
@@ -41,7 +42,7 @@ jobs:
     needs: get-github-repositories
     strategy:
       matrix:
-        repository: fromJSON('${{ needs.outputs.repositories }}')
+        repository: fromJSON('${{ needs.get-github-repositories.outputs.repositories }}')
 
     steps:
       - name: POST default branch name to OpsLevel

--- a/.github/workflows/send-default-branch-name-to-opslevel.yaml
+++ b/.github/workflows/send-default-branch-name-to-opslevel.yaml
@@ -2,9 +2,8 @@ name: Send default branch name to OpsLevel
 
 on:
   schedule:
-    - cron: "0 9,16 * * *"
+    - cron: "0 9,12,16 * * *"
   workflow_dispatch:
-  push:
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
@@ -47,6 +46,5 @@ jobs:
 
     steps:
       - name: POST default branch name to OpsLevel
-        if: github.event.action != 'push'
         run: |
           echo '{ "repository": "${{ matrix.repository.repository }}", "defaultBranch": "${{ matrix.repository.defaultBranch }}" }' | curl --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 40 -X POST https://app.opslevel.com/integrations/custom_event/4e9ed0d8-b835-47ab-948f-628e04448ce8 -H 'content-type: application/json' --data-binary @-

--- a/.github/workflows/send-default-branch-name-to-opslevel.yaml
+++ b/.github/workflows/send-default-branch-name-to-opslevel.yaml
@@ -34,7 +34,7 @@ jobs:
             core.info('Fetched repositories:')
             core.info(names.join(',\n'))
 
-            const mapped = repositories.map(r => ({ repository: r.name, defaultBranch: r.default_branch }))
+            const mapped = repositories.filter(r => !r.archived).map(r => ({ repository: r.name, defaultBranch: r.default_branch }))
             return mapped
 
   send-to-opslevel:

--- a/.github/workflows/send-default-branch-name-to-opslevel.yaml
+++ b/.github/workflows/send-default-branch-name-to-opslevel.yaml
@@ -1,0 +1,48 @@
+name: Send default branch name to OpsLevel
+
+on:
+  schedule:
+    - cron: "0 9,16 * * *"
+  workflow_dispatch:
+  push:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  get-github-repositories:
+    name: Fetch repositories from GitHub
+    runs-on: ubuntu-latest
+    outputs:
+      repositories: ${{ steps.fetch-all-repositories.outputs.result }}
+
+    steps:
+      - name: Get all repositories
+        uses: actions/github-script@v6
+        id: fetch-all-repositories
+        with:
+          result-encoding: string
+          script: |
+            const repositories = await github.paginate("GET /repos/pleo-io/repos", {
+              per_page: 100,
+              headers: {
+                "X-GitHub-Api-Version": "2022-11-28",
+              },
+            })
+
+            return JSON.stringify(repositories)
+
+  post-opslevel:
+    name: Fetch repositories from GitHub
+    runs-on: ubuntu-latest
+    needs: get-github-repositories
+    strategy:
+      matrix:
+        repository: fromJSON(${{ needs.outputs.repositories }})
+
+    steps:
+      - name: POST default branch name to OpsLevel
+        if: github.event.event_name != 'push'
+        run: |
+          echo '{ "repository": "${{ matrix.repository.name }}", "defaultBranch": "${{ matrix.repository.default_branch }}" }' | curl --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 40 -X POST https://app.opslevel.com/integrations/custom_event/4e9ed0d8-b835-47ab-948f-628e04448ce8 -H 'content-type: application/json' --data-binary @-

--- a/.github/workflows/send-default-branch-name-to-opslevel.yaml
+++ b/.github/workflows/send-default-branch-name-to-opslevel.yaml
@@ -18,19 +18,11 @@ jobs:
       repositories: ${{ steps.fetch-all-repositories.outputs.result }}
 
     steps:
-      - name: Allow pushing version updates to the default branch
-        id: get-admin-token
-        uses: peter-murray/workflow-application-token-action@v2
-        with:
-          application_id: ${{ secrets.PLEO_GH_APP_TOKEN_SIGNER_APP_ID }}
-          application_private_key: ${{ secrets.PLEO_GH_APP_TOKEN_SIGNER_PRIVATE_KEY }}
-
       - name: Get all repositories
         uses: actions/github-script@v6
         id: fetch-all-repositories
-        env:
-          GITHUB_TOKEN: ${{ steps.get-admin-token.outputs.token }}
         with:
+          github-token: ${{ secrets.PLEO_READ_TOKEN }}
           script: |
             const repositories = await github.paginate("GET /orgs/pleo-io/repos?type=all", {
               per_page: 100,

--- a/.github/workflows/send-default-branch-name-to-opslevel.yaml
+++ b/.github/workflows/send-default-branch-name-to-opslevel.yaml
@@ -42,7 +42,7 @@ jobs:
     needs: get-github-repositories
     strategy:
       matrix:
-        repository: fromJSON(${{ needs.get-github-repositories.outputs.repositories }})
+        repository: ${{ needs.get-github-repositories.outputs.repositories }}
 
     steps:
       - name: POST default branch name to OpsLevel

--- a/.github/workflows/send-default-branch-name-to-opslevel.yaml
+++ b/.github/workflows/send-default-branch-name-to-opslevel.yaml
@@ -22,7 +22,6 @@ jobs:
         uses: actions/github-script@v6
         id: fetch-all-repositories
         with:
-          result-encoding: string
           script: |
             const repositories = await github.paginate("GET /orgs/pleo-io/repos", {
               per_page: 100,
@@ -30,11 +29,11 @@ jobs:
                 "X-GitHub-Api-Version": "2022-11-28",
               },
             })
-            const stringified = JSON.stringify(repositories)
+            const names = repositories.map(r => r.name)
             core.info('Fetched repositories:')
-            core.info(stringified)
+            core.info(names)
 
-            return stringified
+            return repositories
 
   post-opslevel:
     name: Fetch repositories from GitHub
@@ -42,7 +41,7 @@ jobs:
     needs: get-github-repositories
     strategy:
       matrix:
-        repository: ${{ needs.get-github-repositories.outputs.repositories }}
+        repository: ${{ fromJSON(needs.get-github-repositories.outputs.repositories) }}
 
     steps:
       - name: POST default branch name to OpsLevel

--- a/.github/workflows/send-default-branch-name-to-opslevel.yaml
+++ b/.github/workflows/send-default-branch-name-to-opslevel.yaml
@@ -23,7 +23,7 @@ jobs:
         id: fetch-all-repositories
         with:
           script: |
-            const repositories = await github.paginate("GET /orgs/pleo-io/repos", {
+            const repositories = await github.paginate("GET /orgs/pleo-io/repos?type=all", {
               per_page: 100,
               headers: {
                 "X-GitHub-Api-Version": "2022-11-28",
@@ -31,7 +31,7 @@ jobs:
             })
             const names = repositories.map(r => r.name)
             core.info('Fetched repositories:')
-            core.info(names)
+            core.info(names.join(',\n'))
 
             return repositories
 
@@ -45,6 +45,6 @@ jobs:
 
     steps:
       - name: POST default branch name to OpsLevel
-        if: github.event.event_name != 'push'
+        if: github.event.action != 'push'
         run: |
           echo '{ "repository": "${{ matrix.repository.name }}", "defaultBranch": "${{ matrix.repository.default_branch }}" }' | curl --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 40 -X POST https://app.opslevel.com/integrations/custom_event/4e9ed0d8-b835-47ab-948f-628e04448ce8 -H 'content-type: application/json' --data-binary @-


### PR DESCRIPTION
This moves our OpsLevel `POST` workflow from `centralized-templates` and reworks the workflow to:
- Fetch all repositories
- `POST` all repositories with relevant data to OpsLevel