### PR TITLE
Use `documentation` type

### DIFF
--- a/opslevel.yml
+++ b/opslevel.yml
@@ -42,4 +42,4 @@ service:
       #  - `hiring-challenge` for our hiring challenge
 
     - key: type
-      value: configuration
+      value: documentation


### PR DESCRIPTION
This PR sets a new type for our `.gtihub` repository: `documentation`