### PR TITLE
[DEVX-3102] Add Port's config file using values from opslevel.yml

### DIFF
--- a/port.yaml
+++ b/port.yaml
@@ -1,0 +1,35 @@
+---
+# (required) Owner must map to a valid automated-teams team name.
+# To validate, check if your team is a child team of https://github.com/orgs/pleo-io/teams/automated-teams
+# Format is team name only without `pleo-io/` prefix
+steward: team-devx
+# Any tags relevant to your services and/or mandated by platform teams, such as data classification tags
+tags:
+  # Which type of service the repository defines. 
+  #
+  # Use:
+  #  - `service` for web services (moons)
+  #  - `application` for downloadable software (such as an iOS/Android app,
+  #     CLI tool, standalone executable). This also includes e.g. web apps.
+  #  - `library` for software used by other components
+  #  - `configuration` for repos that contain pure configuration (such as
+  #    setup of DangerJS or Renovate).
+  #  - `documentation` for repos that mostly contain documentation.
+  #  - `hiring-challenge` for our hiring challenges.
+  - key: type
+    value: documentation
+# (optional) Relevant repositories which are relevant to this component excluding the repository hosting this file. The current repository will be linked by default in Port.
+# Example: Terraform folder which hosts the architecture definition for a backend service (moon)
+#related_repositories:
+#  - name: pleo-io/terraform
+#    path: /components/moons/potato
+#    provider: github
+#    display_name: potato @ terraform
+# (optional) The notion page related to this application or owning team
+notion: https://www.notion.so/pleo/DevX-19e7debed9164a6bb2c1caf121edc0a5
+# (optional) A linear view with issues relevant to this application or a link to the linear team for the owning team
+#linear: https://linear.app/pleo/
+# (optional) Any internal or external tool linked to this application such as monitors, logs, documentation, third-party apps, etc.
+#tools:
+#  - name: "Datadog logs: product-dev"
+#    url: https://app.datadoghq.eu/logs?query=env%3Aproduct-dev&agg_m=count&agg_m_source=base&agg_t=count&messageDisplay=inline&storage=hot&stream_sort=desc&viz=streams


### PR DESCRIPTION
This PR adds a new port configuration file, which picks values from opslevel.yml
The `port-values.yaml` file will eventually replace the opslevel.yml config when the migration to Port is complete before end of January 2025

Note that values that are not ported from opslevel.yml, such as `language`, will still be present in Port but fetched from other sources instead, such as the Github `repository` payload

Linear issue: [DEVX-3102]](https://linear.app/pleo/issue/DEVX-3102/opslevelyml-ports-json-config-file-migration-for-devx-services)
